### PR TITLE
Add Trust Establishment Work Item

### DIFF
--- a/work_items/README.md
+++ b/work_items/README.md
@@ -1,3 +1,5 @@
 # Active Work Items
 
 - [Presentation Exchange](./presentation_exchange.md)
+- [Credential Manifest](./credential_manifest.md)
+- [Trust Establishment](./trust_establishment.md)

--- a/work_items/credential_manifest.md
+++ b/work_items/credential_manifest.md
@@ -2,7 +2,7 @@
 
 ## Work Item Owners
 - Dan Buchner (@csuwildcat)
-- Gabe Cohen (@glcohen)
+- Gabe Cohen (@decentralgabe)
 
 ## Outcome
 **When your work item is successful, then what will have changed in the world? What
@@ -35,7 +35,7 @@ Audiance are developers implementing issuer-subject interactions around the disc
 - **What are related resources or standards from DIF or adjacent
   organizations?**
 
-DIF Presentation Exchange, 3C Verifiable Credentials, JSON-LD Signatures, JWT, OpenID Connect, CHAPI, and DID-SIOP.
+DIF Presentation Exchange, W3C Verifiable Credentials, JSON-LD Signatures, JWT, OpenID Connect, CHAPI, and DID-SIOP.
 
 ## Meetings
 - **Are there regular meetings? If so, when?**

--- a/work_items/trust_establishment.md
+++ b/work_items/trust_establishment.md
@@ -1,0 +1,62 @@
+# Trust Establishment
+
+Trust in the decentralized space is a wide problem that many have tried to solve. In this work item we aim to take a piece of the problem around _trust establishment_. Decentralized trust establishment is the means by which parties answer two key questions about one another:
+
+1. Are you who you claim to be?
+2. Are you to be trusted for what you claim to be trusted for?
+
+
+## Work Item Owners
+- Gabe Cohen (@decentralgabe)
+- ...
+
+## Outcome
+**When your work item is successful, then what will have changed in the world? What will we be able to do that wasn't possible do before or vice versa?**
+
+Parties using Decentralized Identifier-relative protocols, and the applications build on top of them, will be able to interrogate, investigate, and establish trust in an common, standards-based method.
+
+## Deliverables
+- **Does your work item have any deliverables? These include code projects,
+  standards-track specifications, reports, registries, summaries, blog posts,
+  and anything else that is instantiable and publishable in written form to a
+  broader audience.**
+
+  We aim to at least deliver a standard format for representing Trust Lists. 
+  Expanding on Trust Lists, we aim to produce an implementer's guide for creating, using, and evolving Trust Lists. This implementers guide is likely to touch on prior art such as the [Well Known DID Configuration](https://identity.foundation/.well-known/resources/did-configuration/) and other existing means for trust establishment.
+
+- **What's the expected timeline?**
+
+  We aim to publish a first draft by the end of Q3, 2022 -- June 15.
+
+- **Who's the audience of your deliverables?**
+
+  Any individual or organization that relies upon Decentralized Identifiers, especially for use-cases of interoperability across open and siloed ecosystems.
+
+- **What are related resources or standards from DIF or adjacent organizations?**
+
+  - DIF: [Well Known DID Configuration](https://identity.foundation/.well-known/resources/did-configuration/)
+  - DIF: [Presentation Exchange](https://identity.foundation/presentation-exchange/)
+  - IETF: [RFC5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile](https://datatracker.ietf.org/doc/html/rfc5280)
+  - ToIP: [Introduction to Trust Over IP](https://www.trustoverip.org/wp-content/uploads/Introduction-to-ToIP-V2.0-2021-11-17.pdf)
+  - ToIP: [Trust Registry Specification](https://github.com/trustoverip/tswg-trust-registry-tf)
+
+## Meetings
+- **Are there regular meetings? If so, when?**
+  TBD
+
+- **What are the goals of the meeting?**
+  1. Agree on deliverables
+  2. Work towards deliverables (e.g. spec work, open and organize issues, assign work, review and merge PRs)
+  3. Publicly represent the work (e.g. at DIF all hands, IIW, between standards bodies, etc.)
+
+- **Do you have specific discussion topics in mind, or is it meant to move a
+  deliverable forward?**
+  Start open ended based on the content of this document, get more specific around specifications, protocols, and possible deliverables.
+
+- **Where are the notes and recordings published, if any?**
+    
+  The recordings will be published in the #general channel on the DIF Slack. Notes are not required, though, if taken, they'll be present in the GitHub repository for the work item (to be created).
+
+- **Who might be interested in attending?**
+
+  Anyone interested in establishing DID-relative trust, or working on similar governance frameworks.


### PR DESCRIPTION
- Add trust establishment work item
- Have yet to reach out to co-owners, will do that ASAP (likely Trinsic and Indicio folks)
- Made some other (minor) edits

Question for the chairs: there are [mentions to Notion](https://github.com/decentralized-identity/claims-credentials#creating-a-new-work-item) but others that note its deprecation. What is the correct process should the work item move forward?